### PR TITLE
fix: resolve mobile share image 404 error

### DIFF
--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -1990,7 +1990,8 @@ export default function Demo({ title = "Fun Quotes" }) {
                         try {
                           const dataUrl = await generateQuoteImage(quote, bgImage, context);
                           const uploadedUrl = await uploadImage(dataUrl);
-                          mediaUrl = encodeURIComponent(uploadedUrl);
+                          // Don't encode the full URL, as Warpcast will handle that
+                          mediaUrl = uploadedUrl;
                         } catch (error) {
                           console.error('Error generating/uploading image:', error);
                         }


### PR DESCRIPTION
- Remove URL encoding for media URLs in share functionality
- Let Warpcast handle URL encoding internally